### PR TITLE
Removed irrelevant comment since not using .refresh() after

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,46 @@
+name: Run FastAPI Tests
+
+on:
+  push:
+    branches:
+      - main
+      - remove-comment
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:15
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: gloryness
+          POSTGRES_DB: fastapi_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Run tests
+        env:
+          DATABASE_URL: postgresql+psycopg://postgres:gloryness@localhost:5432/fastapi_test
+        run: pytest -v

--- a/main.py
+++ b/main.py
@@ -128,7 +128,7 @@ async def update_item(item_id: int, updates: ItemUpdate, db: AsyncSession = Depe
     for field, value in updates.dict(exclude_unset=True).items():
         setattr(db_item, field, value)
 
-    await db.commit() # After commit , the SQLAlchemy object in memory doesn't automatically get updated with the auto-generated values like id or timestamps.
+    await db.commit()
     return db_item
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+fastapi
+uvicorn
+sqlalchemy
+psycopg[binary]
+httpx
+pytest
+pytest-asyncio


### PR DESCRIPTION
To demonstrate how .refresh() affects SQLAlchemy in-memory I added a comment after .commit() : I did this in 2 different places but only ever ended up using .refresh() in one place hence the other place for the comment became unnessecary.